### PR TITLE
Add Multi-Objective Optimization Support

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -101,11 +101,15 @@ Study
 load_study
 delete_study
 copy_study
+directions
 ask
 tell
 best_trial
+best_trials
 best_params
+best_params_all
 best_value
+best_values
 upload_artifact
 get_all_artifact_meta
 download_artifact

--- a/examples/optimize_moo_unconstrained.jl
+++ b/examples/optimize_moo_unconstrained.jl
@@ -20,8 +20,8 @@ study = Study(
     study_name,
     artifact_store,
     storage;
-    sampler=NSGAIISampler(population_size=50),
-    directions=["minimize", "minimize"]
+    sampler=NSGAIISampler(; population_size=50),
+    directions=["minimize", "minimize"],
 )
 
 # Step 4: Define objective functions

--- a/examples/optimize_moo_unconstrained.jl
+++ b/examples/optimize_moo_unconstrained.jl
@@ -1,0 +1,47 @@
+using Optuna
+
+# Central database storage for all studies
+database_url = "examples/storage"
+database_name = "example_db"
+
+# Name and artifact path for the study
+study_name = "example-study"
+artifact_path = "examples/artifacts"
+
+# Step 1: Create/Load database storage for studies
+storage_url = create_sqlite_url(database_url, database_name)
+storage = RDBStorage(storage_url)
+
+# Step 2: Create artifact store for the study
+artifact_store = FileSystemArtifactStore(artifact_path)
+
+# Step 3: Create a new study (or load an existing one)
+study = Study(
+    study_name,
+    artifact_store,
+    storage;
+    sampler=NSGAIISampler(population_size=50),
+    directions=["minimize", "minimize"]
+)
+
+# Step 4: Define objective functions
+obj1(x) = x^2
+obj2(x) = (x - 2)^2
+
+schaffer(trial::Trial) =
+    let x = suggest_float(trial, "x", -10.0, 10.0)
+        [obj1(x), obj2(x)]
+    end
+
+# Step 5: Optimize the objective function of the study
+optimize(study, schaffer; n_trials=10, n_jobs=1, verbose=true)
+
+# Step 6: Retrieve best trial information
+println("Best trials: ", best_trials(study))
+println("Best params: ", best_params_all(study))
+
+pareto = best_values(study)
+println("Pareto front: $(length(pareto)) solutions")
+for v in pareto
+    println("  f1=$(round(v[1], digits=4))  f2=$(round(v[2], digits=4))")
+end

--- a/src/Optuna.jl
+++ b/src/Optuna.jl
@@ -66,6 +66,7 @@ export suggest_int, suggest_float, suggest_categorical, report, should_prune
 export load_study, delete_study, copy_study
 export ask, tell
 export best_trial, best_params, best_value
+export directions, best_trials, best_values, best_params_all
 export upload_artifact, get_all_artifact_meta, download_artifact
 # optimize.jl
 export optimize

--- a/src/study.jl
+++ b/src/study.jl
@@ -383,7 +383,7 @@ best trial in a vector.
 - `study::Study`: The study to query. (see [Study](@ref))
 """
 function best_trials(study::Study)
-    return pyconvert(Vector, study.study.best_trials)
+    return Trial{false}.(pyconvert(Vector, study.study.best_trials))
 end
 
 """

--- a/src/study.jl
+++ b/src/study.jl
@@ -190,6 +190,24 @@ function ask(study::Study; multithreading::Bool=Threads.nthreads() > 1)
     end
 end
 
+function _validate_objectives(study::Study, objectives)
+    isnothing(objectives) && return
+    n_dirs = pyconvert(Int, study.study.directions.__len__())
+    if objectives isa Vector
+        length(objectives) == n_dirs || throw(
+            ArgumentError(
+                "The number of objectives ($(length(objectives))) does not match the number of directions provided ($n_dirs)."
+            )
+        )
+    else
+        n_dirs == 1 || throw(
+            ArgumentError(
+                "A scalar objective was provided but the study has multiple directions ($n_dirs)."
+            )
+        )
+    end
+end
+
 """
     tell(
         study::Study,
@@ -221,6 +239,8 @@ function tell(
         )
     end
 
+    _validate_objectives(study, score)
+
     if prune
         study.study.tell(trial.trial; state=optuna.trial.TrialState.PRUNED)
     else
@@ -241,6 +261,8 @@ function tell(
             ),
         )
     end
+
+    _validate_objectives(study, score)
 
     thread_safe() do
         if prune
@@ -343,9 +365,7 @@ Single-objective studies return a one-element vector.
 - `Vector{String}`: Each element is "minimize" or "maximize".
 """
 function directions(study::Study)
-    let dirs = pyconvert(Vector{Int64}, study.study.directions)
-      [dir == 1 ? "minimize" : "maximize" for dir in dirs]
-    end
+    return [lowercase(pyconvert(String, d.name)) for d in study.study.directions]
 end
 
 """

--- a/src/study.jl
+++ b/src/study.jl
@@ -11,6 +11,7 @@
         sampler::Union{Nothing,BaseSampler}=nothing,
         pruner::Union{Nothing,BasePruner}=nothing,
         direction::String="minimize",
+        directions::Union{Nothing,Vector{String}}=nothing,
         load_if_exists::Bool=true,
     )
 
@@ -25,7 +26,8 @@ For further information see the [create_study](https://optuna.readthedocs.io/en/
 ## Keyword Arguments
 - `sampler::Union{Nothing,BaseSampler}=nothing`: Sampler to use for the study. (see [Sampler](@ref))
 - `pruner::Union{Nothing,BasePruner}=nothing`: Pruner to use for the study. (see [Pruner](@ref))
-- `direction::String="minimize"`: Direction of optimization, either "minimize" or "maximize".
+- `direction::String="minimize"`: Direction of optimization for single-objective studies, either "minimize" or "maximize". Ignored when `directions` is provided.
+- `directions::Union{Nothing,Vector{String}}=nothing`: Directions of optimization for multi-objective studies. Each element must be "minimize" or "maximize". When provided, `direction` is ignored and a multi-objective study is created.
 - `load_if_exists::Bool=true`: If true, load the study if it already exists.
 
 ## Returns
@@ -38,20 +40,37 @@ function Study(
     sampler::Union{Nothing,BaseSampler}=nothing,
     pruner::Union{Nothing,BasePruner}=nothing,
     direction::String="minimize",
+    directions::Union{Nothing,Vector{String}}=nothing,
     load_if_exists::Bool=true,
 )
-    if direction != "minimize" && direction != "maximize"
-        error("Direction of optimization must be either 'minimize' or 'maximize'")
-    end
+    py_sampler = isnothing(sampler) ? nothing : sampler.sampler
+    py_pruner = isnothing(pruner) ? nothing : pruner.pruner
 
-    study = optuna.create_study(;
-        storage=storage.storage,
-        study_name=study_name,
-        sampler=isnothing(sampler) ? nothing : sampler.sampler,
-        pruner=isnothing(pruner) ? nothing : pruner.pruner,
-        direction=direction,
-        load_if_exists=load_if_exists,
-    )
+    if !isnothing(directions)
+        for d in directions
+            d ∈ ("minimize", "maximize") ||
+                error("Each element of directions must be 'minimize' or 'maximize', got '$d'")
+        end
+        study = optuna.create_study(;
+            storage=storage.storage,
+            study_name=study_name,
+            sampler=py_sampler,
+            pruner=py_pruner,
+            directions=directions,
+            load_if_exists=load_if_exists,
+        )
+    else
+        direction ∈ ("minimize", "maximize") ||
+            error("Direction of optimization must be either 'minimize' or 'maximize'")
+        study = optuna.create_study(;
+            storage=storage.storage,
+            study_name=study_name,
+            sampler=py_sampler,
+            pruner=py_pruner,
+            direction=direction,
+            load_if_exists=load_if_exists,
+        )
+    end
 
     return Study(study, artifact_store, storage)
 end
@@ -237,7 +256,7 @@ end
         study::Study
     )
 
-Get the best trial of the study.
+Get the best trial of the study. Only valid for single-objective studies.
 For further information see the [best_trial](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.study.Study.html#optuna.study.Study.best_trial) in the Optuna python documentation.
 
 ## Arguments
@@ -247,6 +266,9 @@ For further information see the [best_trial](https://optuna.readthedocs.io/en/st
 - `Trial`: The best trial. (see [Trial](@ref))
 """
 function best_trial(study::Study)
+    pyconvert(Int, study.study.directions.__len__()) > 1 &&
+        error("best_trial() is not defined for multi-objective studies. " *
+              "Use best_trials() to get the Pareto front trials.")
     return Trial{false}(study.study.best_trial)
 end
 
@@ -255,7 +277,7 @@ end
         study::Study
     )
 
-Get the best parameters of the study.
+Get the best parameters of the study. Only valid for single-objective studies.
 For further information see the [best_params](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.study.Study.html#optuna.study.Study.best_params) in the Optuna python documentation.
 
 ## Arguments
@@ -265,7 +287,26 @@ For further information see the [best_params](https://optuna.readthedocs.io/en/s
 - `Dict{String,Any}`: The best parameters.
 """
 function best_params(study::Study)
+    pyconvert(Int, study.study.directions.__len__()) > 1 &&
+        error("best_params() is not defined for multi-objective studies. " *
+              "Use best_params_all() to get the parameters for all Pareto front trials.")
     return pyconvert(Dict{String,Any}, study.study.best_params)
+end
+
+"""
+    best_params_all(study::Study) -> Vector{Dict{String,Any}}
+
+Return the parameter dictionaries for every Pareto-optimal trial.
+For single-objective studies this wraps the single best trial's parameters in a vector.
+
+## Arguments
+- `study::Study`: The study to query. (see [Study](@ref))
+
+## Returns
+- `Vector{Dict{String,Any}}`: One dictionary per Pareto-optimal trial.
+"""
+function best_params_all(study::Study)
+    return [pyconvert(Dict{String,Any}, t.params) for t in study.study.best_trials]
 end
 
 """
@@ -273,7 +314,7 @@ end
         study::Study
     )
 
-Get the best objective value of the study.
+Get the best objective value of the study. Only valid for single-objective studies.
 For further information see the [best_value](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.study.Study.html#optuna.study.Study.best_value) in the Optuna python documentation.
 
 ## Arguments
@@ -283,5 +324,54 @@ For further information see the [best_value](https://optuna.readthedocs.io/en/st
 - `Float64`: The best objective value.
 """
 function best_value(study::Study)
+    pyconvert(Int, study.study.directions.__len__()) > 1 &&
+        error("best_value() is not defined for multi-objective studies. " *
+              "Use best_values() to get the Pareto front objective values.")
     return pyconvert(Float64, study.study.best_value)
+end
+
+"""
+    directions(study::Study) -> Vector{String}
+
+Return the optimization directions of the study, one per objective.
+Single-objective studies return a one-element vector.
+
+## Arguments
+- `study::Study`: The study to query. (see [Study](@ref))
+
+## Returns
+- `Vector{String}`: Each element is "minimize" or "maximize".
+"""
+function directions(study::Study)
+    return pyconvert(Vector{String}, study.study.directions)
+end
+
+"""
+    best_trials(study::Study) -> Vector
+
+Return all Pareto-optimal trials (the Pareto front) of a multi-objective study.
+Each element is a Python `FrozenTrial`; fields `.values`, `.params`, and `.number`
+are accessible via PythonCall. For single-objective studies this wraps the single
+best trial in a vector.
+
+## Arguments
+- `study::Study`: The study to query. (see [Study](@ref))
+"""
+function best_trials(study::Study)
+    return pyconvert(Vector, study.study.best_trials)
+end
+
+"""
+    best_values(study::Study) -> Vector{Vector{Float64}}
+
+Return the objective value vectors for every Pareto-optimal trial.
+
+## Arguments
+- `study::Study`: The study to query. (see [Study](@ref))
+
+## Returns
+- `Vector{Vector{Float64}}`: One inner vector per Pareto-optimal trial.
+"""
+function best_values(study::Study)
+    return [pyconvert(Vector{Float64}, t.values) for t in study.study.best_trials]
 end

--- a/src/study.jl
+++ b/src/study.jl
@@ -48,8 +48,9 @@ function Study(
 
     if !isnothing(directions)
         for d in directions
-            d ∈ ("minimize", "maximize") ||
-                error("Each element of directions must be 'minimize' or 'maximize', got '$d'")
+            d ∈ ("minimize", "maximize") || error(
+                "Each element of directions must be 'minimize' or 'maximize', got '$d'"
+            )
         end
         study = optuna.create_study(;
             storage=storage.storage,
@@ -163,7 +164,7 @@ end
 
 """
     ask(
-        study::Study; 
+        study::Study;
         multithreading::Bool=Threads.nthreads() > 1
     )
 
@@ -191,19 +192,19 @@ function ask(study::Study; multithreading::Bool=Threads.nthreads() > 1)
 end
 
 function _validate_objectives(study::Study, objectives)
-    isnothing(objectives) && return
+    isnothing(objectives) && return nothing
     n_dirs = pyconvert(Int, study.study.directions.__len__())
     if objectives isa Vector
         length(objectives) == n_dirs || throw(
             ArgumentError(
-                "The number of objectives ($(length(objectives))) does not match the number of directions provided ($n_dirs)."
-            )
+                "The number of objectives ($(length(objectives))) does not match the number of directions provided ($n_dirs).",
+            ),
         )
     else
         n_dirs == 1 || throw(
             ArgumentError(
-                "A scalar objective was provided but the study has multiple directions ($n_dirs)."
-            )
+                "A scalar objective was provided but the study has multiple directions ($n_dirs).",
+            ),
         )
     end
 end
@@ -262,9 +263,8 @@ function tell(
         )
     end
 
-    _validate_objectives(study, score)
-
     thread_safe() do
+        _validate_objectives(study, score)
         if prune
             study.study.tell(trial.trial; state=optuna.trial.TrialState.PRUNED)
         else
@@ -288,9 +288,10 @@ For further information see the [best_trial](https://optuna.readthedocs.io/en/st
 - `Trial`: The best trial. (see [Trial](@ref))
 """
 function best_trial(study::Study)
-    pyconvert(Int, study.study.directions.__len__()) > 1 &&
-        error("best_trial() is not defined for multi-objective studies. " *
-              "Use best_trials() to get the Pareto front trials.")
+    pyconvert(Int, study.study.directions.__len__()) > 1 && error(
+        "best_trial() is not defined for multi-objective studies. " *
+        "Use best_trials() to get the Pareto front trials.",
+    )
     return Trial{false}(study.study.best_trial)
 end
 
@@ -309,9 +310,10 @@ For further information see the [best_params](https://optuna.readthedocs.io/en/s
 - `Dict{String,Any}`: The best parameters.
 """
 function best_params(study::Study)
-    pyconvert(Int, study.study.directions.__len__()) > 1 &&
-        error("best_params() is not defined for multi-objective studies. " *
-              "Use best_params_all() to get the parameters for all Pareto front trials.")
+    pyconvert(Int, study.study.directions.__len__()) > 1 && error(
+        "best_params() is not defined for multi-objective studies. " *
+        "Use best_params_all() to get the parameters for all Pareto front trials.",
+    )
     return pyconvert(Dict{String,Any}, study.study.best_params)
 end
 
@@ -346,9 +348,10 @@ For further information see the [best_value](https://optuna.readthedocs.io/en/st
 - `Float64`: The best objective value.
 """
 function best_value(study::Study)
-    pyconvert(Int, study.study.directions.__len__()) > 1 &&
-        error("best_value() is not defined for multi-objective studies. " *
-              "Use best_values() to get the Pareto front objective values.")
+    pyconvert(Int, study.study.directions.__len__()) > 1 && error(
+        "best_value() is not defined for multi-objective studies. " *
+        "Use best_values() to get the Pareto front objective values.",
+    )
     return pyconvert(Float64, study.study.best_value)
 end
 

--- a/src/study.jl
+++ b/src/study.jl
@@ -343,7 +343,9 @@ Single-objective studies return a one-element vector.
 - `Vector{String}`: Each element is "minimize" or "maximize".
 """
 function directions(study::Study)
-    return pyconvert(Vector{String}, study.study.directions)
+    let dirs = pyconvert(Vector{Int64}, study.study.directions)
+      [dir == 1 ? "minimize" : "maximize" for dir in dirs]
+    end
 end
 
 """

--- a/test/optimize_moo_unconstrained.jl
+++ b/test/optimize_moo_unconstrained.jl
@@ -2,11 +2,12 @@
     storage = InMemoryStorage()
     artifact_store = FileSystemArtifactStore(mktempdir())
     study = Study(
-                "moo_unconstrained_test", 
-                artifact_store, 
-                storage;
-                sampler=NSGAIISampler(population_size=10),
-                directions=["minimize", "minimize"])
+        "moo_unconstrained_test",
+        artifact_store,
+        storage;
+        sampler=NSGAIISampler(; population_size=10),
+        directions=["minimize", "minimize"],
+    )
 
     obj1(x) = x^2
     obj2(x) = (x - 2)^2
@@ -29,7 +30,9 @@
     @test best_params_all(study) isa Vector{Dict{String,Any}}
     @test best_trials(study) isa Vector
 
-    @test length(best_trials(study)) == length(best_values(study)) == length(best_params_all(study))
+    @test length(best_trials(study)) ==
+        length(best_values(study)) ==
+        length(best_params_all(study))
 
     best_x = best_params_all(study)[1]["x"]
     @test best_x isa Float64

--- a/test/optimize_moo_unconstrained.jl
+++ b/test/optimize_moo_unconstrained.jl
@@ -1,0 +1,39 @@
+@testset "moo_unconstrained_test" begin
+    storage = InMemoryStorage()
+    artifact_store = FileSystemArtifactStore(mktempdir())
+    study = Study(
+                "moo_unconstrained_test", 
+                artifact_store, 
+                storage;
+                sampler=NSGAIISampler(population_size=10),
+                directions=["minimize", "minimize"])
+
+    obj1(x) = x^2
+    obj2(x) = (x - 2)^2
+
+    schaffer(trial::Trial) =
+        let x = suggest_float(trial, "x", -10.0, 10.0)
+            [obj1(x), obj2(x)]
+        end
+
+    optimize(study, schaffer; n_trials=5, n_jobs=1, verbose=false)
+
+    @test length(best_trials(study)) >= 1
+    @test all(length(v) == 2 for v in best_values(study))
+
+    @test_throws ErrorException best_value(study)
+    @test_throws ErrorException best_params(study)
+    @test_throws ErrorException best_trial(study)
+
+    @test best_values(study) isa Vector{Vector{Float64}}
+    @test best_params_all(study) isa Vector{Dict{String,Any}}
+    @test best_trials(study) isa Vector
+
+    @test length(best_trials(study)) == length(best_values(study)) == length(best_params_all(study))
+
+    best_x = best_params_all(study)[1]["x"]
+    @test best_x isa Float64
+    @test all(-10.0 <= p["x"] <= 10.0 for p in best_params_all(study))
+    @test all(all(v >= 0.0 for v in vals) for vals in best_values(study))
+    @test all(all(isfinite(v) for v in vals) for vals in best_values(study))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ using Test
     include("trial.jl")
     include("study.jl")
     include("optimize.jl")
+    include("optimize_moo_unconstrained.jl")
     include("optimize_multithreading.jl")
     include("single_step.jl")
 end

--- a/test/study.jl
+++ b/test/study.jl
@@ -21,9 +21,22 @@
             @test study isa Study
         end
 
+        # multi-objective with directions
+        create_test_study(;
+            study_name="multi_obj_test", directions=["minimize", "maximize"]
+        ) do study, _
+            @test study isa Study
+            @test directions(study) == ["minimize", "maximize"]
+        end
+
         # invalid direction should error
         @test_throws ErrorException create_test_study(
             (_, _) -> nothing; study_name="invalid_test", direction="invalid"
+        )
+        @test_throws ErrorException create_test_study(
+            (_, _) -> nothing;
+            study_name="invalid_test2",
+            directions=["minimize", "invalid"],
         )
     end
 
@@ -34,6 +47,17 @@
 
             x = suggest_float(trial, "x", 0.0, 10.0)
             tell(study, trial, x)
+        end
+        create_test_study(;
+            study_name="multi_obj_ask_tell_test", directions=["minimize", "maximize"]
+        ) do study, _
+            trial = ask(study)
+
+            x = suggest_float(trial, "x", 0.0, 10.0)
+            tell(study, trial, [x, 10.0 - x])
+
+            trial = ask(study)
+            @test_throws ArgumentError tell(study, trial, [1.0, 2.0, 3.0])
         end
     end
 
@@ -50,6 +74,23 @@
             @test best_value(study) isa Float64
             @test best_params(study) isa Dict{String,Any}
             @test best_trial(study) isa Trial
+        end
+
+        create_test_study(;
+            study_name="best_multi_test", directions=["minimize", "maximize"]
+        ) do study, _
+            # run a few multi-objective trials
+            for vals in [[5.0, 1.0], [3.0, 2.0], [7.0, 0.5]]
+                trial = ask(study)
+                suggest_float(trial, "x", 0.0, 10.0)
+                tell(study, trial, vals)
+            end
+
+            best_vals = best_values(study)
+            @test length(best_vals) == 1
+            @test best_vals[1] == [3.0, 2.0]
+            @test best_params_all(study) isa Vector{Dict{String,Any}}
+            @test best_trials(study) isa Vector
         end
     end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -11,6 +11,7 @@ function create_test_study(
     sampler=RandomSampler(),
     pruner=MedianPruner(),
     direction="minimize",
+    directions=nothing,
 )
     database_path = joinpath(path, "storage")
     artifact_path = joinpath(path, "artifacts")
@@ -37,6 +38,7 @@ function create_test_study(
         sampler=sampler,
         pruner=pruner,
         direction=direction,
+        directions=directions,
         load_if_exists=true,
     )
 


### PR DESCRIPTION
- Changed the `study` method with an additional input parameter, called `directions`, which must be a vector of strings with the desired optimization directions (`"minimize"`, `"maximize"`). This is not a breaking change, as `direction` is still present. However, if `directions` is provided, it will override `direction`. 
- Added the private method `_validate_objectives` to ensure the number of directions matches the number of objectives.
- Added the methods `best_trials`, `best_values`, and `best_params_all`. They are equivalent to the ones already implemented (`best_trial`, `best_value`, `best_params`), but related to the Pareto optimal trials.
- Added the method `directions`, which returns an array with the study's directions. Works with a single objective, as well.
- Added both tests and an example of a multi-objective optimization problem.

