### PR TITLE
Added support for frozen and FixedTrial

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -119,6 +119,8 @@ download_artifact
 
 ```@docs
 Trial
+FixedTrial
+is_frozen
 suggest_int
 suggest_float
 suggest_categorical

--- a/src/Optuna.jl
+++ b/src/Optuna.jl
@@ -50,7 +50,7 @@ export RDBStorage, InMemoryStorage, JournalStorage
 # artifacts.jl
 export FileSystemArtifactStore, ArtifactMeta
 # trial.jl
-export Trial
+export Trial, FixedTrial
 # study.jl
 export Study
 # optimize.jl
@@ -61,7 +61,7 @@ export is_conda_pkg_installed, add_conda_pkg
 # storage.jl
 export get_all_study_names, create_sqlite_url, create_mysql_url, create_redis_url
 # trial.jl
-export suggest_int, suggest_float, suggest_categorical, report, should_prune
+export suggest_int, suggest_float, suggest_categorical, report, should_prune, is_frozen
 # study.jl
 export load_study, delete_study, copy_study
 export ask, tell

--- a/src/trial.jl
+++ b/src/trial.jl
@@ -31,20 +31,39 @@ For further information see the [suggest_int](https://optuna.readthedocs.io/en/s
 - `T`: Suggested integer value.
 """
 function suggest_int(
-    trial::Trial{false}, name::String, low::T, high::T; step::T=1, log::Bool=false
+    trial::Union{Trial{false},FixedTrial{false}},
+    name::String,
+    low::T,
+    high::T;
+    step::T=1,
+    log::Bool=false,
 ) where {T<:Signed}
     @assert !(step != 1 && log) "The parameters `step` and `log` cannot be used " *
         "at the same time when suggesting an integer."
     return pyconvert(T, trial.trial.suggest_int(name, low, high; step=step, log=log))
 end
 function suggest_int(
-    trial::Trial{true}, name::String, low::T, high::T; step::T=1, log::Bool=false
+    trial::Union{Trial{true},FixedTrial{true}},
+    name::String,
+    low::T,
+    high::T;
+    step::T=1,
+    log::Bool=false,
 ) where {T<:Signed}
     @assert !(step != 1 && log) "The parameters `step` and `log` cannot be used " *
         "at the same time when suggesting an integer."
     thread_safe() do
         return pyconvert(T, trial.trial.suggest_int(name, low, high; step=step, log=log))
     end
+end
+
+"""
+    is_frozen(trial::Trial)
+
+Check if the given trial wraps an Optuna frozen trial.
+"""
+function is_frozen(trial::Trial)
+    return pyconvert(Bool, PythonCall.pytype(trial.trial) == optuna.trial.FrozenTrial)
 end
 
 """
@@ -74,7 +93,7 @@ For further information see the [suggest_float](https://optuna.readthedocs.io/en
 - `Float64`: Suggested float value.
 """
 function suggest_float(
-    trial::Trial,
+    trial::Union{Trial,FixedTrial},
     name::String,
     low::T,
     high::T;
@@ -94,7 +113,7 @@ function suggest_float(
 end
 
 function suggest_float(
-    trial::Trial{false},
+    trial::Union{Trial{false},FixedTrial{false}},
     name::String,
     low::Float64,
     high::Float64;
@@ -109,7 +128,7 @@ function suggest_float(
 end
 
 function suggest_float(
-    trial::Trial{true},
+    trial::Union{Trial{true},FixedTrial{true}},
     name::String,
     low::Float64,
     high::Float64;
@@ -155,6 +174,18 @@ function suggest_categorical(
         return pyconvert(T, trial.trial.suggest_categorical(name, choices))
     end
 end
+function suggest_categorical(
+    trial::FixedTrial{false}, name::String, choices::Union{Vector{T},Tuple{Vararg{T}}}
+) where {T<:Union{Bool,Int,AbstractFloat,String}}
+    return pyconvert(T, trial.trial.suggest_categorical(name, choices))
+end
+function suggest_categorical(
+    trial::FixedTrial{true}, name::String, choices::Union{Vector{T},Tuple{Vararg{T}}}
+) where {T<:Union{Bool,Int,AbstractFloat,String}}
+    thread_safe() do
+        return pyconvert(T, trial.trial.suggest_categorical(name, choices))
+    end
+end
 
 """
     suggest_categorical(
@@ -177,20 +208,46 @@ For further information see the [suggest_categorical](https://optuna.readthedocs
 function suggest_categorical(
     trial::Trial{false}, name::String, choices::Union{Vector{T},Tuple{Vararg{T}}}
 ) where {T}
-    choices_str = ["$i|$v" for (i, v) in enumerate(choices)]
-    choice = pyconvert(String, trial.trial.suggest_categorical(name, choices_str))
-    choice_idx = parse(Int, split(choice, '|')[1])
-    return choices[choice_idx]
+    return _suggest_categorical(trial, name, choices)
 end
 function suggest_categorical(
     trial::Trial{true}, name::String, choices::Union{Vector{T},Tuple{Vararg{T}}}
 ) where {T}
     thread_safe() do
-        choices_str = ["$i|$v" for (i, v) in enumerate(choices)]
-        choice = pyconvert(String, trial.trial.suggest_categorical(name, choices_str))
-        choice_idx = parse(Int, split(choice, '|')[1])
-        return choices[choice_idx]
+        return _suggest_categorical(trial, name, choices)
     end
+end
+function suggest_categorical(
+    trial::FixedTrial{false}, name::String, choices::Union{Vector{T},Tuple{Vararg{T}}}
+) where {T}
+    return _suggest_fixed_categorical(trial, name, choices)
+end
+function suggest_categorical(
+    trial::FixedTrial{true}, name::String, choices::Union{Vector{T},Tuple{Vararg{T}}}
+) where {T}
+    thread_safe() do
+        return _suggest_fixed_categorical(trial, name, choices)
+    end
+end
+
+function _suggest_categorical(
+    trial::Trial, name::String, choices::Union{Vector{T},Tuple{Vararg{T}}}
+) where {T}
+    choices_str = ["$i|$v" for (i, v) in enumerate(choices)]
+    choice = pyconvert(String, trial.trial.suggest_categorical(name, choices_str))
+    choice_idx = parse(Int, split(choice, '|')[1])
+    return choices[choice_idx]
+end
+function _suggest_fixed_categorical(
+    trial::FixedTrial, name::String, choices::Union{Vector{T},Tuple{Vararg{T}}}
+) where {T}
+    haskey(trial.params, name) ||
+        throw(ArgumentError("FixedTrial does not contain parameter `$name`."))
+    value = trial.params[name]
+    for choice in choices
+        choice == value && return choice
+    end
+    throw(ArgumentError("FixedTrial parameter `$name` is not one of the provided choices."))
 end
 
 """
@@ -208,10 +265,12 @@ For further information see the [report](https://optuna.readthedocs.io/en/stable
 - `value::AbstractFloat`: The intermediate value to report.
 - `step::Int`: The step at which the value is reported.
 """
-function report(trial::Trial{false}, value::AbstractFloat, step::Int)
+function report(
+    trial::Union{Trial{false},FixedTrial{false}}, value::AbstractFloat, step::Int
+)
     return trial.trial.report(value; step=step)
 end
-function report(trial::Trial{true}, value::AbstractFloat, step::Int)
+function report(trial::Union{Trial{true},FixedTrial{true}}, value::AbstractFloat, step::Int)
     thread_safe() do
         return trial.trial.report(value; step=step)
     end
@@ -231,10 +290,10 @@ For further information see the [should_prune](https://optuna.readthedocs.io/en/
 ## Returns
 - `Bool`: `true` if the trial should be pruned, `false` otherwise.
 """
-function should_prune(trial::Trial{false})
+function should_prune(trial::Union{Trial{false},FixedTrial{false}})
     return Bool(trial.trial.should_prune())
 end
-function should_prune(trial::Trial{true})
+function should_prune(trial::Union{Trial{true},FixedTrial{true}})
     thread_safe() do
         return Bool(trial.trial.should_prune())
     end

--- a/src/trial.jl
+++ b/src/trial.jl
@@ -62,8 +62,13 @@ end
 
 Check if the given trial wraps an Optuna frozen trial.
 """
-function is_frozen(trial::Trial)
+function is_frozen(trial::Trial{false})
     return pyconvert(Bool, PythonCall.pytype(trial.trial) == optuna.trial.FrozenTrial)
+end
+function is_frozen(trial::Trial{true})
+    thread_safe() do
+        return pyconvert(Bool, PythonCall.pytype(trial.trial) == optuna.trial.FrozenTrial)
+    end
 end
 
 """
@@ -230,10 +235,13 @@ function suggest_categorical(
     end
 end
 
+function _categorical_choice_key(i::Integer, choice)
+    return "$i|$choice"
+end
 function _suggest_categorical(
     trial::Trial, name::String, choices::Union{Vector{T},Tuple{Vararg{T}}}
 ) where {T}
-    choices_str = ["$i|$v" for (i, v) in enumerate(choices)]
+    choices_str = [_categorical_choice_key(i, v) for (i, v) in enumerate(choices)]
     choice = pyconvert(String, trial.trial.suggest_categorical(name, choices_str))
     choice_idx = parse(Int, split(choice, '|')[1])
     return choices[choice_idx]
@@ -244,8 +252,11 @@ function _suggest_fixed_categorical(
     haskey(trial.params, name) ||
         throw(ArgumentError("FixedTrial does not contain parameter `$name`."))
     value = trial.params[name]
-    for choice in choices
+    for (i, choice) in enumerate(choices)
         choice == value && return choice
+        value isa AbstractString &&
+            value == _categorical_choice_key(i, choice) &&
+            return choice
     end
     throw(ArgumentError("FixedTrial parameter `$name` is not one of the provided choices."))
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -26,8 +26,8 @@ abstract type BaseStorage end
 # study.jl
 """
     Study(
-        study, 
-        artifact_store, 
+        study,
+        artifact_store,
         storage
     )
 
@@ -43,7 +43,7 @@ end
 
 """
     Trial(
-        trial, 
+        trial,
         multithreading::Bool=false
     )
 
@@ -51,4 +51,28 @@ Trial is a data structure wrapper for an Optuna trial.
 """
 struct Trial{multithreading}
     trial::Any
+end
+
+"""
+    FixedTrial(
+        params::Dict;
+        number::Int=0,
+        multithreading::Bool=false,
+    )
+
+FixedTrial is a data structure wrapper for an Optuna fixed trial.
+"""
+struct FixedTrial{multithreading}
+    trial::Any
+    params::Dict
+
+    function FixedTrial(params::Dict; number::Int=0, multithreading::Bool=false)
+        if multithreading
+            thread_safe() do
+                return new{true}(optuna.trial.FixedTrial(params, number), params)
+            end
+        else
+            return new{false}(optuna.trial.FixedTrial(params, number), params)
+        end
+    end
 end

--- a/test/trial.jl
+++ b/test/trial.jl
@@ -12,6 +12,11 @@
 
             tell(study, trial, 1.0)
 
+            threaded_trial = ask(study; multithreading=true)
+            @test !is_frozen(threaded_trial)
+
+            tell(study, threaded_trial, 1.0)
+
             frozen_trial = best_trial(study)
             @test is_frozen(frozen_trial)
         end
@@ -44,6 +49,28 @@
         choice_b = FixedTrialTestStruct(3, 4.0)
         fixed_struct = FixedTrial(Dict("s" => choice_b))
         @test suggest_categorical(fixed_struct, "s", [choice_a, choice_b]) == choice_b
+
+        fixed_encoded_struct = FixedTrial(Dict("s" => "2|$choice_b"))
+        @test suggest_categorical(
+            fixed_encoded_struct, "s", [choice_a, choice_b]
+        ) == choice_b
+        @test_throws ArgumentError suggest_categorical(
+            FixedTrial(Dict("s" => "3|$choice_b")), "s", [choice_a, choice_b]
+        )
+
+        create_test_study(; study_name="fixed_trial_encoded_categorical_test") do study, _
+            choices = [choice_a, choice_b]
+            trial = ask(study)
+            selected = suggest_categorical(trial, "s", choices)
+            tell(study, trial, 1.0)
+
+            params = best_params(study)
+            @test params["s"] isa String
+            @test suggest_categorical(FixedTrial(params), "s", choices) == selected
+            @test suggest_categorical(
+                FixedTrial(params; multithreading=true), "s", choices
+            ) == selected
+        end
 
         fixed_multithreaded = FixedTrial(Dict("func" => cos); multithreading=true)
         @test suggest_categorical(fixed_multithreaded, "func", [sin, cos, tan]) == cos

--- a/test/trial.jl
+++ b/test/trial.jl
@@ -34,6 +34,9 @@
         fixed_categorical = FixedTrial(Dict("y" => "b"))
         @test suggest_categorical(fixed_categorical, "y", ["a", "b"]) == "b"
 
+        fixed_categorical_multithreaded = FixedTrial(Dict("y" => "b"); multithreading=true)
+        @test suggest_categorical(fixed_categorical_multithreaded, "y", ["a", "b"]) == "b"
+
         fixed_func = FixedTrial(Dict("func" => sin))
         @test suggest_categorical(fixed_func, "func", [sin, cos, tan]) == sin
 

--- a/test/trial.jl
+++ b/test/trial.jl
@@ -51,9 +51,8 @@
         @test suggest_categorical(fixed_struct, "s", [choice_a, choice_b]) == choice_b
 
         fixed_encoded_struct = FixedTrial(Dict("s" => "2|$choice_b"))
-        @test suggest_categorical(
-            fixed_encoded_struct, "s", [choice_a, choice_b]
-        ) == choice_b
+        @test suggest_categorical(fixed_encoded_struct, "s", [choice_a, choice_b]) ==
+            choice_b
         @test_throws ArgumentError suggest_categorical(
             FixedTrial(Dict("s" => "3|$choice_b")), "s", [choice_a, choice_b]
         )

--- a/test/trial.jl
+++ b/test/trial.jl
@@ -4,6 +4,58 @@
 #
 
 @testset "trial" begin
+    @testset "trial types" begin
+        create_test_study(; study_name="trial_type_test") do study, _
+            trial = ask(study)
+
+            @test !is_frozen(trial)
+
+            tell(study, trial, 1.0)
+
+            frozen_trial = best_trial(study)
+            @test is_frozen(frozen_trial)
+        end
+    end
+
+    @testset "FixedTrial" begin
+        struct FixedTrialTestStruct
+            a::Int
+            b::AbstractFloat
+        end
+
+        fixed_int = FixedTrial(Dict("x" => 1); number=7)
+        @test fixed_int isa FixedTrial
+        @test suggest_int(fixed_int, "x", 0, 10) == 1
+        @test Optuna.PythonCall.pyconvert(Int, fixed_int.trial.number) == 7
+
+        fixed_float = FixedTrial(Dict("x" => 1.5))
+        @test suggest_float(fixed_float, "x", 0.0, 2.0) == 1.5
+
+        fixed_categorical = FixedTrial(Dict("y" => "b"))
+        @test suggest_categorical(fixed_categorical, "y", ["a", "b"]) == "b"
+
+        fixed_func = FixedTrial(Dict("func" => sin))
+        @test suggest_categorical(fixed_func, "func", [sin, cos, tan]) == sin
+
+        choice_a = FixedTrialTestStruct(1, 2.0f0)
+        choice_b = FixedTrialTestStruct(3, 4.0)
+        fixed_struct = FixedTrial(Dict("s" => choice_b))
+        @test suggest_categorical(fixed_struct, "s", [choice_a, choice_b]) == choice_b
+
+        fixed_multithreaded = FixedTrial(Dict("func" => cos); multithreading=true)
+        @test suggest_categorical(fixed_multithreaded, "func", [sin, cos, tan]) == cos
+
+        @test_throws ArgumentError suggest_categorical(
+            FixedTrial(Dict("func" => sqrt)), "func", [sin, cos, tan]
+        )
+        @test_throws ArgumentError suggest_categorical(
+            FixedTrial(Dict{String,Any}()), "missing", [sin, cos, tan]
+        )
+
+        report(fixed_int, 1.0, 0)
+        @test !should_prune(fixed_int)
+    end
+
     @testset "suggest_int" begin
         create_test_study(; study_name="suggest_int_test") do study, _
             trial = ask(study)


### PR DESCRIPTION
## Summary

Adds `FixedTrial` support and frozen trial detection to the Optuna wrapper.

## Changes

- Exports `FixedTrial` and `is_frozen`
- Adds `is_frozen` to distinguish default and frozen trials
- Adds a `FixedTrial` wrapper with support for fixed int, float, and categorical suggestions
- Extends `report` and `should_prune` to work with fixed trials
- Adds tests for frozen trial detection and fixed-trial behavior, including arbitrary Julia categorical values

## Testing

Ran full test suite, tests passed