### PR TITLE
Updated docstrings & docs

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -26,47 +26,23 @@ JournalFileOpenLock
 ```@docs
 FileSystemArtifactStore
 ArtifactMeta
+upload_artifact
+get_all_artifact_meta
+download_artifact
 ```
 
 ## Sampler
 
 ```@docs
 RandomSampler
-```
-
-```@docs
 TPESampler
-```
-
-```@docs
 GPSampler
-```
-
-```@docs
 CmaEsSampler
-```
-
-```@docs
 NSGAIISampler
-```
-
-```@docs
 NSGAIIISampler
-```
-
-```@docs
 GridSampler
-```
-
-```@docs
 QMCSampler
-```
-
-```@docs
 BruteForceSampler
-```
-
-```@docs
 PartialFixedSampler
 ```
 
@@ -110,9 +86,6 @@ best_params
 best_params_all
 best_value
 best_values
-upload_artifact
-get_all_artifact_meta
-download_artifact
 ```
 
 ## Trial

--- a/src/artifacts.jl
+++ b/src/artifacts.jl
@@ -8,9 +8,9 @@ using JLD2
 """
     FileSystemArtifactStore(
         path::String
-    )
+    ) <: BaseArtifactStore
 
-Data structure for a file system based artifact store.
+Struct for a file system based artifact store.
 For further information see the [FileSystemArtifactStore](https://optuna.readthedocs.io/en/stable/reference/artifacts.html#optuna.artifacts.FileSystemArtifactStore) in the Optuna python documentation.
 
 ## Arguments
@@ -31,7 +31,7 @@ end
 """
     ArtifactMeta
 
-Data structure containing metadata for an artifact.
+Struct containing metadata for an artifact.
 For further information see the [ArtifactMeta](https://optuna.readthedocs.io/en/stable/reference/artifacts.html#optuna.artifacts.ArtifactMeta) in the Optuna python documentation.
 """
 struct ArtifactMeta
@@ -42,8 +42,8 @@ end
 
 """
     upload_artifact(
-        study::Study, 
-        trial::Trial, 
+        study::Study,
+        trial::Trial,
         data::Dict
     )
 
@@ -108,7 +108,7 @@ end
 
 """
     get_all_artifact_meta(
-        study::Study, 
+        study::Study,
         trial
     )
 
@@ -141,8 +141,8 @@ end
 
 """
     download_artifact(
-        study::Study, 
-        artifact_id::String, 
+        study::Study,
+        artifact_id::String,
         file_path::String
     )
 

--- a/src/crossover.jl
+++ b/src/crossover.jl
@@ -6,9 +6,9 @@
 """
     UniformCrossover(
         swapping_prob::Float64=0.5
-    )
+    ) <: BaseCrossover
 
-Select each parameter with equal probability from the two parent individuals. 
+Select each parameter with equal probability from the two parent individuals.
 For further information see the [UniformCrossover](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.nsgaii.UniformCrossover.html) in the Optuna python documentation.
 
 ## Arguments
@@ -26,7 +26,7 @@ end
 """
     BLXAlphaCrossover(
         alpha::Float64=0.5
-    )
+    ) <: BaseCrossover
 
 Uniformly samples child individuals from the hyper-rectangles created by the two parent individuals.
 For further information see the [BLXAlphaCrossover](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.nsgaii.BLXAlphaCrossover.html) in the Optuna python documentation.
@@ -46,7 +46,7 @@ end
 """
     SPXCrossover(
         epsilon::Union{Nothing,Float64}=nothing
-    )
+    ) <: BaseCrossover
 
 Uniformly samples child individuals from within a single simplex that is similar to the simplex produced by the parent individual.
 For further information see the [SPXCrossover](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.nsgaii.SPXCrossover.html) in the Optuna python documentation.
@@ -68,7 +68,7 @@ end
         eta::Union{Nothing,Float64}=nothing,
         uniform_crossover_prob::Float64=0.5,
         use_child_gene_prob::Float64=0.5,
-    )
+    ) <: BaseCrossover
 
 Uniformly samples child individuals from within a single simplex that is similar to the simplex produced by the parent individual.
 For further information see the [SBXCrossover](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.nsgaii.SBXCrossover.html) in the Optuna python documentation.
@@ -98,7 +98,7 @@ end
         eta::Union{Nothing,Float64}=nothing,
         uniform_crossover_prob::Float64=0.5,
         use_child_gene_prob::Float64=0.5,
-    )
+    ) <: BaseCrossover
 
 vSBX generates child individuals without excluding any region of the parameter space, while maintaining the excellent properties of SBX.
 For further information see the [VSBXCrossover](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.nsgaii.VSBXCrossover.html) in the Optuna python documentation.
@@ -125,9 +125,9 @@ end
 
 """
     UNDXCrossover(
-        sigma_xi::Float64=0.5, 
+        sigma_xi::Float64=0.5,
         sigma_eta::Union{Nothing,Float64}=nothing
-    )
+    ) <: BaseCrossover
 
 Generates child individuals from the three parents using a multivariate normal distribution.
 For further information see the [UNDXCrossover](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.nsgaii.UNDXCrossover.html) in the Optuna python documentation.

--- a/src/journal.jl
+++ b/src/journal.jl
@@ -5,9 +5,9 @@
 
 """
     JournalFileSymlinkLock(
-        file_path::String, 
+        file_path::String,
         grace_period::Union{Nothing,Int}=30
-    )
+    ) <: BaseJournalFileLock
 
 Lock class for synchronizing processes for NFSv2 or later.
 For further information see the [JournalFileSymlinkLock](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.storages.journal.JournalFileSymlinkLock.html) in the Optuna python documentation.
@@ -26,9 +26,9 @@ end
 
 """
     JournalFileOpenLock(
-        file_path::String, 
-        grace_period::Union{Nothing,Int}=30}
-    )
+        file_path::String,
+        grace_period::Union{Nothing,Int}=30
+    ) <: BaseJournalFileLock
 
 Lock class for synchronizing processes for NFSv3 or later.
 For further information see the [JournalFileOpenLock](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.storages.journal.JournalFileOpenLock.html) in the Optuna python documentation.
@@ -47,9 +47,9 @@ end
 
 """
     JournalFileBackend(
-        file_path::String; 
+        file_path::String;
         lock_obj::Union{Nothing,BaseJournalFileLock}=nothing
-    )
+    ) <: BaseJournalBackend
 
 File storage class for Journal log backend.
 For further information see the [JournalFileBackend](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.storages.journal.JournalFileBackend.html) in the Optuna python documentation.
@@ -76,10 +76,10 @@ end
 
 """
     JournalRedisBackend(
-        url::String, 
-        use_cluster::Bool=false, 
+        url::String,
+        use_cluster::Bool=false,
         prefix::String=""
-    )
+    ) <: BaseJournalBackend
 
 Redis storage class for Journal log backend.
 For further information see the [JournalRedisBackend](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.storages.journal.JournalRedisBackend.html) in the Optuna python documentation.

--- a/src/pruners.jl
+++ b/src/pruners.jl
@@ -8,7 +8,7 @@
         n_startup_trials::Int=5,
         n_warmup_steps::Int=0,
         interval_steps::Int=1;
-        n_min_trials::Int=1)
+        n_min_trials::Int=1) <: BasePruner
 
 Pruner using the median stopping rule. Prune if the trial's best intermediate result is worse than median of intermediate results of previous trials at the same step.
 For further information see the [MedianPruner](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.pruners.MedianPruner.html) in the Optuna python documentation.
@@ -36,7 +36,7 @@ struct MedianPruner <: BasePruner
 end
 
 """
-    NopPruner()
+    NopPruner() <: BasePruner
 
 Pruner which never prunes trials.
 For further information see the [NopPruner](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.pruners.NopPruner.html) in the Optuna python documentation.
@@ -55,7 +55,7 @@ end
     PatientPruner(
         wrapped_pruner::Union{BasePruner,Nothing},
         patience::Int;
-        min_delta::Float64=0.0)
+        min_delta::Float64=0.0) <: BasePruner
 
 Pruner which wraps another pruner with tolerance. This pruner monitors intermediate values in a trial and prunes the trial if the improvement in the intermediate values after a patience period is less than a threshold.
 For further information see the [PatientPruner](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.pruners.PatientPruner.html) in the Optuna python documentation.
@@ -83,7 +83,7 @@ end
         n_startup_trials::Int=5,
         n_warmup_steps::Int=0,
         interval_steps::Int=1;
-        n_min_trials::Int=1)
+        n_min_trials::Int=1) <: BasePruner
 
 Pruner to keep the specified percentile of the trials. Prune if the best intermediate value is in the bottom percentile among trials at the same step.
 For further information see the [PercentilePruner](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.pruners.PercentilePruner.html) in the Optuna python documentation.
@@ -121,7 +121,7 @@ end
         min_resource::Union{String,Int}="auto",
         reduction_factor::Int=4,
         min_early_stopping_rate::Int=0,
-        bootstrap_count::Int=0)
+        bootstrap_count::Int=0) <: BasePruner
 
 Pruner using Asynchronous Successive Halving Algorithm.
 For further information see the [SuccessiveHalvingPruner](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.pruners.SuccessiveHalvingPruner.html) in the Optuna python documentation.
@@ -156,7 +156,7 @@ end
         min_resource::Int=1,
         max_resource::Union{String,Int}="auto",
         reduction_factor::Int=3,
-        bootstrap_count::Int=0)
+        bootstrap_count::Int=0) <: BasePruner
 
 Pruner using Hyperband.
 For further information see the [HyperbandPruner](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.pruners.HyperbandPruner.html) in the Optuna python documentation.
@@ -191,7 +191,7 @@ end
         lower::Union{Float64,Nothing}=nothing,
         upper::Union{Float64,Nothing}=nothing,
         n_warmup_steps::Int=0,
-        interval_steps::Int=1)
+        interval_steps::Int=1) <: BasePruner
 
 Pruner to detect outlying metrics of the trials. Prune if a metric exceeds upper threshold, falls behind lower threshold or reaches NaN.
 For further information see the [ThresholdPruner](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.pruners.ThresholdPruner.html) in the Optuna python documentation.
@@ -224,7 +224,7 @@ end
 """
     WilcoxonPruner(;
         p_threshold::Float64=0.1,
-        n_startup_steps::Int=2)
+        n_startup_steps::Int=2) <: BasePruner
 
 Pruner based on the Wilcoxon signed-rank test. This pruner performs the Wilcoxon signed-rank test between the current trial and the current best trial, and stops whenever the pruner is sure up to a given p-value that the current trial is worse than the best one.
 For further information see the [WilcoxonPruner](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.pruners.WilcoxonPruner.html) in the Optuna python documentation.

--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -4,7 +4,7 @@
 #
 
 """
-    RandomSampler(seed=nothing::Union{Nothing,Integer})
+    RandomSampler(seed=nothing::Union{Nothing,Integer}) <: BaseSampler
 
 An independent sampler that samples randomly.
 For further information see the [RandomSampler](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.RandomSampler.html#optuna-samplers-randomsampler) in the Optuna python documentation.
@@ -38,7 +38,7 @@ end
         constant_liar::Bool=false,
         constraints_func::Union{Nothing,Function}=nothing,
         categorical_distance_func::Union{Nothing,Function}=nothing,
-    )
+    ) <: BaseSampler
 
 Sampler using TPE (Tree-structured Parzen Estimator) algorithm.
 For further information see the [TPESampler](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.TPESampler.html#optuna-samplers-tpesampler) in the Optuna python documentation.
@@ -115,7 +115,7 @@ end
         deterministic_objective::Bool=false,
         constraints_func::Union{Nothing,Function}=nothing,
         warn_independent_sampling::Bool=true,
-    )
+    ) <: BaseSampler
 
 Sampler using Gaussian process-based Bayesian optimization.
 For further information see the [GPSampler](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.GPSampler.html#optuna-samplers-gpsampler) in the Optuna python documentation.
@@ -171,7 +171,7 @@ end
         with_margin::Bool=false,
         lr_adapt::Bool=false,
         source_trials::Union{Nothing,Vector{Trial}}=nothing,
-    )
+    ) <: BaseSampler
 
 A sampler using cmaes as the backend.
 For further information see the [CmaEsSampler](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.CmaEsSampler.html#optuna-samplers-cmaessampler) in the Optuna python documentation.
@@ -252,7 +252,7 @@ end
         elite_population_selection_strategy::Union{Nothing,Function}=nothing,
         child_generation_strategy::Union{Nothing,Function}=nothing,
         after_trial_strategy::Union{Nothing,Function}=nothing,
-    )
+    ) <: BaseSampler
 
 Multi-objective sampler using the NSGA-II algorithm.
 For further information see the [NSGAIISampler](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.NSGAIISampler.html#optuna-samplers-nsgaiisampler) in the Optuna python documentation.
@@ -318,7 +318,7 @@ end
         elite_population_selection_strategy::Union{Nothing,Function}=nothing,
         child_generation_strategy::Union{Nothing,Function}=nothing,
         after_trial_strategy::Union{Nothing,Function}=nothing,
-    ) where {T}
+    ) where {T} <: BaseSampler
 
 Multi-objective sampler using the NSGA-III algorithm.
 For further information see the [NSGAIIISampler](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.NSGAIIISampler.html#optuna-samplers-nsgaiiisampler) in the Optuna python documentation.
@@ -380,7 +380,7 @@ end
     GridSampler(
         search_space::Dict{String,Vector},
         seed::Union{Nothing,Integer}=nothing
-    )
+    ) <: BaseSampler
 
 Sampler using grid search.
 For further information see the [GridSampler](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.GridSampler.html#optuna-samplers-gridsampler) in the Optuna python documentation.
@@ -408,7 +408,7 @@ end
         independent_sampler::Union{Nothing,BaseSampler}=nothing,
         warn_asynchronous_seeding::Bool=true,
         warn_independent_sampling::Bool=true,
-    )
+    ) <: BaseSampler
 
 A Quasi Monte Carlo Sampler that generates low-discrepancy sequences.
 For further information see the [QMCSampler](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.QMCSampler.html#optuna-samplers-qmcsampler) in the Optuna python documentation.
@@ -453,7 +453,7 @@ end
     BruteForceSampler(
         seed::Union{Nothing,Integer}=nothing,
         avoid_premature_stop::Bool=false
-    )
+    ) <: BaseSampler
 
 Sampler using brute force. This sampler performs exhaustive search on the defined search space.
 For further information see the [BruteForceSampler](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.BruteForceSampler.html#optuna-samplers-bruteforcesampler) in the Optuna python documentation.
@@ -479,7 +479,7 @@ end
 """
     PartialFixedSampler(
         fixed_params::Dict{String,Any},
-        base_sampler::BaseSampler)
+        base_sampler::BaseSampler) <: BaseSampler
 
 Sampler with partially fixed parameters.
 For further information see the [PartialFixedSampler](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.PartialFixedSampler.html#optuna-samplers-partialfixedsampler) in the Optuna python documentation.

--- a/src/storage.jl
+++ b/src/storage.jl
@@ -5,7 +5,7 @@
 """
     RDBStorage(
         url::String
-    )
+    ) <: BaseStorage
 
 Storage class for RDB backends.
 For further information see the [RDBStorage](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.storages.RDBStorage.html) in the Optuna python documentation.
@@ -27,7 +27,7 @@ struct RDBStorage <: BaseStorage
 end
 
 """
-    InMemoryStorage()
+    InMemoryStorage() <: BaseStorage
 
 Storage class that stores data in memory of the running process.
 For further information see the [InMemoryStorage](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.storages.InMemoryStorage.html) in the Optuna python documentation.
@@ -43,7 +43,7 @@ end
 """
     JournalStorage(
         backend::BaseJournalBackend
-    )
+    ) <: BaseStorage
 
 Storage class for Journal storage backend.
 For further information see the [JournalStorage](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.storages.JournalStorage.html) in the Optuna python documentation.
@@ -79,7 +79,7 @@ end
 
 """
     create_sqlite_url(
-        database_path::String, 
+        database_path::String,
         database_name::String
     )
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -26,12 +26,12 @@ abstract type BaseStorage end
 # study.jl
 """
     Study(
-        study, 
-        artifact_store, 
+        study,
+        artifact_store,
         storage
     )
 
-This data structure represents an Optuna study and its corresponding artifact and data storage. A study is a collection of trials that share the same optimization objective.
+This struct represents an Optuna study and its corresponding artifact and data storage. A study is a collection of trials that share the same optimization objective.
 """
 struct Study
     study::Any
@@ -43,11 +43,11 @@ end
 
 """
     Trial(
-        trial, 
+        trial,
         multithreading::Bool=false
     )
 
-Trial is a data structure wrapper for an Optuna trial.
+Trial is a struct wrapper for an Optuna trial.
 """
 struct Trial{multithreading}
     trial::Any


### PR DESCRIPTION
Adds small API documentation cleanup across the package.
- Groups artifact helpers under the Artifacts API section.
- Consolidates sampler docs into a single @docs block.
- Updates docstring signatures to show their abstract supertype relationships.
- Cleans up wording and minor formatting in docstrings.
- Fixes the JournalFileOpenLock docstring signature typo.