### PR TITLE
Fixed artifact handling

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -99,6 +99,7 @@ suggest_float
 suggest_categorical
 report
 should_prune
+set_user_attr
 ```
 
 ## Optimization

--- a/src/Optuna.jl
+++ b/src/Optuna.jl
@@ -67,6 +67,7 @@ export load_study, delete_study, copy_study
 export ask, tell
 export best_trial, best_params, best_value
 export directions, best_trials, best_values, best_params_all
+export set_user_attr
 export upload_artifact, get_all_artifact_meta, download_artifact
 # optimize.jl
 export optimize

--- a/src/artifacts.jl
+++ b/src/artifacts.jl
@@ -54,35 +54,42 @@ For further information see the [upload_artifact](https://optuna.readthedocs.io/
 - `study::Study`: The study to upload the artifact to. (see [Study](@ref))
 - `trial::Trial`: The trial to associate the artifact with. (see [Trial](@ref))
 - `data::Dict`: The data to be stored as an artifact.
+
+## Returns
+- `String`: The uploaded artifact ID.
 """
 function upload_artifact(study::Study, trial::Trial{false}, data::Dict)
     artifact_file = joinpath(study.artifact_store.path, "artifact.jld2")
 
     JLD2.save(artifact_file, data)
-    artifact_id = optuna.artifacts.upload_artifact(;
-        artifact_store=study.artifact_store.artifact_store,
-        file_path=artifact_file,
-        study_or_trial=trial.trial,
-        storage=study.storage.storage,
-    )
-    trial.trial.set_user_attr("artifact_id", artifact_id)
-
-    return rm(artifact_file)
-end
-function upload_artifact(study::Study, trial::Trial{true}, data::Dict)
-    artifact_file = joinpath(study.artifact_store.path, "artifact.jld2")
-
-    thread_safe() do
-        JLD2.save(artifact_file, data)
+    try
         artifact_id = optuna.artifacts.upload_artifact(;
             artifact_store=study.artifact_store.artifact_store,
             file_path=artifact_file,
             study_or_trial=trial.trial,
             storage=study.storage.storage,
         )
-        trial.trial.set_user_attr("artifact_id", artifact_id)
+        return pyconvert(String, artifact_id)
+    finally
+        rm(artifact_file; force=true)
+    end
+end
+function upload_artifact(study::Study, trial::Trial{true}, data::Dict)
+    artifact_file = joinpath(study.artifact_store.path, "artifact.jld2")
 
-        return rm(artifact_file)
+    thread_safe() do
+        JLD2.save(artifact_file, data)
+        try
+            artifact_id = optuna.artifacts.upload_artifact(;
+                artifact_store=study.artifact_store.artifact_store,
+                file_path=artifact_file,
+                study_or_trial=trial.trial,
+                storage=study.storage.storage,
+            )
+            return pyconvert(String, artifact_id)
+        finally
+            rm(artifact_file; force=true)
+        end
     end
 end
 
@@ -101,9 +108,11 @@ For further information see the [get_all_artifact_meta](https://optuna.readthedo
 - `Vector{ArtifactMeta}`: List of artifact metadata of all artifacts in the study.
 """
 function get_all_artifact_meta(study::Study)
-    return stack([get_all_artifact_meta(study, trial) for trial in study.study.trials])[
-        1, :,
-    ]
+    artifact_metas = ArtifactMeta[]
+    for trial in study.study.trials
+        append!(artifact_metas, get_all_artifact_meta(study, trial))
+    end
+    return artifact_metas
 end
 
 """
@@ -117,11 +126,14 @@ For further information see the [get_all_artifact_meta](https://optuna.readthedo
 
 ## Arguments
 - `study::Study`: The study to get the artifact metadata from. (see [Study](@ref))
-- `trial`: The trial to get the artifact metadata from. (see [Trial](@ref))
+- `trial`: The Julia `Trial` or Python Optuna trial to get the artifact metadata from.
 
 ## Returns
 - `Vector{ArtifactMeta}`: List of artifact metadata of the given trial.
 """
+function get_all_artifact_meta(study::Study, trial::Trial)
+    return get_all_artifact_meta(study, trial.trial)
+end
 function get_all_artifact_meta(study::Study, trial)
     artifact_metas = optuna.artifacts.get_all_artifact_meta(
         trial; storage=study.storage.storage
@@ -152,12 +164,12 @@ For further information see the [download_artifact](https://optuna.readthedocs.i
 ## Arguments
 - `study::Study`: The study to download the artifact from. (see [Study](@ref))
 - `artifact_id::String`: The ID of the artifact to download.
-- `file_path::String`: The path where the downloaded artifact should be stored.
+- `file_path::String`: The exact file path where the downloaded artifact should be stored.
 """
 function download_artifact(study::Study, artifact_id::String, file_path::String)
     return optuna.artifacts.download_artifact(;
         artifact_store=study.artifact_store.artifact_store,
         artifact_id=artifact_id,
-        file_path=abspath(file_path) * "$artifact_id.jld2",
+        file_path=abspath(file_path),
     )
 end

--- a/src/artifacts.jl
+++ b/src/artifacts.jl
@@ -131,8 +131,13 @@ For further information see the [get_all_artifact_meta](https://optuna.readthedo
 ## Returns
 - `Vector{ArtifactMeta}`: List of artifact metadata of the given trial.
 """
-function get_all_artifact_meta(study::Study, trial::Trial)
+function get_all_artifact_meta(study::Study, trial::Trial{false})
     return get_all_artifact_meta(study, trial.trial)
+end
+function get_all_artifact_meta(study::Study, trial::Trial{true})
+    thread_safe() do
+        return get_all_artifact_meta(study, trial.trial)
+    end
 end
 function get_all_artifact_meta(study::Study, trial)
     artifact_metas = optuna.artifacts.get_all_artifact_meta(

--- a/src/trial.jl
+++ b/src/trial.jl
@@ -309,3 +309,27 @@ function should_prune(trial::Union{Trial{true},FixedTrial{true}})
         return Bool(trial.trial.should_prune())
     end
 end
+
+"""
+    set_user_attr(
+        trial::Trial,
+        key::String,
+        value,
+    )
+
+Set a user attribute on the given trial.
+For further information see the [set_user_attr](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.trial.Trial.html#optuna.trial.Trial.set_user_attr) in the Optuna python documentation.
+
+## Arguments
+- `trial::Trial`: The trial to set the user attribute on. (see [Trial](@ref))
+- `key::String`: The user attribute key.
+- `value`: The user attribute value.
+"""
+function set_user_attr(trial::Trial{false}, key::String, value)
+    return trial.trial.set_user_attr(key, value)
+end
+function set_user_attr(trial::Trial{true}, key::String, value)
+    thread_safe() do
+        return trial.trial.set_user_attr(key, value)
+    end
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -5,7 +5,7 @@
 
 """
     is_conda_pkg_installed(
-        pkg_name::String; 
+        pkg_name::String;
         version::Union{Nothing,String}=nothing
     )
 
@@ -32,7 +32,7 @@ end
 
 """
     add_conda_pkg(
-        pkg_name::String; 
+        pkg_name::String;
         version::Union{Nothing,String}=nothing
     )
 

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -36,8 +36,9 @@
 
             set_user_attr(trial, "artifact_id", artifact_id)
             @test Bool(trial.trial.user_attrs.__contains__("artifact_id"))
-            @test Optuna.PythonCall.pyconvert(String, trial.trial.user_attrs["artifact_id"]) ==
-                artifact_id
+            @test Optuna.PythonCall.pyconvert(
+                String, trial.trial.user_attrs["artifact_id"]
+            ) == artifact_id
 
             tell(study, trial, 1.0)
 
@@ -74,8 +75,12 @@
             tell(study, trial_without_artifacts, 2.0)
 
             trial_with_two = ask(study)
-            artifact_id_2 = upload_artifact(study, trial_with_two, Dict("trial" => 3, "idx" => 1))
-            artifact_id_3 = upload_artifact(study, trial_with_two, Dict("trial" => 3, "idx" => 2))
+            artifact_id_2 = upload_artifact(
+                study, trial_with_two, Dict("trial" => 3, "idx" => 1)
+            )
+            artifact_id_3 = upload_artifact(
+                study, trial_with_two, Dict("trial" => 3, "idx" => 2)
+            )
             tell(study, trial_with_two, 3.0)
 
             @test isempty(get_all_artifact_meta(study, trial_without_artifacts))

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -78,6 +78,28 @@
         end
     end
 
+    @testset "metadata lookup dispatch for Julia trials" begin
+        create_test_study(; study_name="artifact_dispatch_test") do study, _
+            trial_false = ask(study; multithreading=false)
+            @test trial_false isa Trial{false}
+            artifact_id_false = upload_artifact(study, trial_false, Dict("trial" => "false"))
+            tell(study, trial_false, 1.0)
+
+            trial_true = ask(study; multithreading=true)
+            @test trial_true isa Trial{true}
+            artifact_id_true = upload_artifact(study, trial_true, Dict("trial" => "true"))
+            tell(study, trial_true, 2.0)
+
+            metas_false = get_all_artifact_meta(study, trial_false)
+            @test length(metas_false) == 1
+            @test metas_false[1].artifact_id == artifact_id_false
+
+            metas_true = get_all_artifact_meta(study, trial_true)
+            @test length(metas_true) == 1
+            @test metas_true[1].artifact_id == artifact_id_true
+        end
+    end
+
     @testset "metadata across trials with uneven artifacts" begin
         create_test_study(; study_name="multi_artifact_test") do study, _
             @test isempty(get_all_artifact_meta(study))

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -25,6 +25,21 @@
         @test meta_with_encoding.encoding == "utf-8"
     end
 
+    @testset "set_user_attr for non-threaded Trial" begin
+        create_test_study(; study_name="set_user_attr_trial_false_test") do study, _
+            trial = ask(study; multithreading=false)
+            @test trial isa Trial{false}
+
+            set_user_attr(trial, "artifact_id", "artifact-123")
+            @test Bool(trial.trial.user_attrs.__contains__("artifact_id"))
+            @test Optuna.PythonCall.pyconvert(
+                String, trial.trial.user_attrs["artifact_id"]
+            ) == "artifact-123"
+
+            tell(study, trial, 1.0)
+        end
+    end
+
     @testset "upload and download artifact" begin
         create_test_study(; study_name="artifact_test") do study, test_dir
             trial = ask(study)

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -82,7 +82,9 @@
         create_test_study(; study_name="artifact_dispatch_test") do study, _
             trial_false = ask(study; multithreading=false)
             @test trial_false isa Trial{false}
-            artifact_id_false = upload_artifact(study, trial_false, Dict("trial" => "false"))
+            artifact_id_false = upload_artifact(
+                study, trial_false, Dict("trial" => "false")
+            )
             tell(study, trial_false, 1.0)
 
             trial_true = ask(study; multithreading=true)

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -27,24 +27,63 @@
 
     @testset "upload and download artifact" begin
         create_test_study(; study_name="artifact_test") do study, test_dir
-            # create a trial and upload artifact
             trial = ask(study)
             data = Dict("model_weights" => [1.0, 2.0, 3.0], "epoch" => 10)
-            upload_artifact(study, trial, data)
+            artifact_id = upload_artifact(study, trial, data)
+            @test artifact_id isa String
+            @test !isempty(artifact_id)
+            @test !Bool(trial.trial.user_attrs.__contains__("artifact_id"))
+
+            set_user_attr(trial, "artifact_id", artifact_id)
+            @test Bool(trial.trial.user_attrs.__contains__("artifact_id"))
+            @test Optuna.PythonCall.pyconvert(String, trial.trial.user_attrs["artifact_id"]) ==
+                artifact_id
+
             tell(study, trial, 1.0)
 
-            # get artifact metadata
             metas = get_all_artifact_meta(study)
             @test length(metas) == 1
             @test metas[1] isa ArtifactMeta
-            @test !isempty(metas[1].artifact_id)
+            @test metas[1].artifact_id == artifact_id
 
-            # download artifact (file_path prefix + artifact_id + .jld2)
-            download_prefix = joinpath(test_dir, "artifact_")
-            download_artifact(study, metas[1].artifact_id, download_prefix)
+            julia_trial_metas = get_all_artifact_meta(study, trial)
+            @test length(julia_trial_metas) == 1
+            @test julia_trial_metas[1].artifact_id == artifact_id
 
-            downloaded_file = abspath(download_prefix) * metas[1].artifact_id * ".jld2"
+            py_trial = first(study.study.trials)
+            py_trial_metas = get_all_artifact_meta(study, py_trial)
+            @test length(py_trial_metas) == 1
+            @test py_trial_metas[1].artifact_id == artifact_id
+
+            downloaded_file = joinpath(test_dir, "downloaded-artifact.jld2")
+            download_artifact(study, artifact_id, downloaded_file)
             @test isfile(downloaded_file)
+            @test !isfile(abspath(downloaded_file) * artifact_id * ".jld2")
+        end
+    end
+
+    @testset "metadata across trials with uneven artifacts" begin
+        create_test_study(; study_name="multi_artifact_test") do study, _
+            @test isempty(get_all_artifact_meta(study))
+
+            trial_with_one = ask(study)
+            artifact_id_1 = upload_artifact(study, trial_with_one, Dict("trial" => 1))
+            tell(study, trial_with_one, 1.0)
+
+            trial_without_artifacts = ask(study)
+            tell(study, trial_without_artifacts, 2.0)
+
+            trial_with_two = ask(study)
+            artifact_id_2 = upload_artifact(study, trial_with_two, Dict("trial" => 3, "idx" => 1))
+            artifact_id_3 = upload_artifact(study, trial_with_two, Dict("trial" => 3, "idx" => 2))
+            tell(study, trial_with_two, 3.0)
+
+            @test isempty(get_all_artifact_meta(study, trial_without_artifacts))
+
+            metas = get_all_artifact_meta(study)
+            artifact_ids = Set(meta.artifact_id for meta in metas)
+            @test length(metas) == 3
+            @test artifact_ids == Set([artifact_id_1, artifact_id_2, artifact_id_3])
         end
     end
 end


### PR DESCRIPTION
This PR updates artifact upload/download and metadata lookup behavior:
- `upload_artifact` now returns the uploaded artifact ID instead of storing it automatically in trial user attrs.
- Added `set_user_attr` so callers can explicitly persist artifact IDs when desired.
- `get_all_artifact_meta(study)` now handles multi-trial studies with uneven or missing artifacts.
- `get_all_artifact_meta(study, trial)` now supports Julia `Trial`s and raw Python Optuna trial objects.
- `download_artifact` now writes to the exact requested file path.

Regression tests were added for returned artifact IDs, explicit user attrs, mixed artifact counts across trials, Python/Julia trial metadata lookup, and exact download paths.