### PR TITLE
Add third-party license attribution and documentation

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -31,10 +31,6 @@ jobs:
           version: '1.11'
           arch: x64
 
-      - name: "Copy readme to doc"
-        run:
-          cp ./README.md ./docs/src/index.md
-
       - name: "Install dependencies"
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Optuna"
 uuid = "a5d0552b-b2dc-4f08-ac5c-85ca7d701b92"
 authors = ["Julian Trommer <julian.trommer@uni-a.de>", "Valentin Höpfner <valentin.hoepfner@uni-a.de>", "Andreas Hofmann <andreas.hofmann@uni-a.de>", "Josef Kircher <josef.kircher@uni-a.de>", "Tobias Thummerer <tobias.thummerer@uni-a.de>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"

--- a/README.md
+++ b/README.md
@@ -67,3 +67,11 @@ println("Best value: ", best_value(study))
 ## How to contribute
 
 Contributors are welcome. Before contributing, please read, understand and follow the [Contributor's Guide](https://github.com/SciML/ColPrac) on Collaborative Practices for Community Packages.
+
+## License
+
+Optuna.jl is available under the [MIT License](LICENSE). Portions of the API
+documentation and interface descriptions are adapted from Optuna, and the
+polynomial-fitting documentation example is adapted from Lux.jl. See
+[`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md) for the applicable
+third-party MIT license texts and attribution.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,75 @@
+# Third-Party Notices
+
+## Optuna
+
+Portions of the API documentation and interface descriptions in the following
+files are adapted from [Optuna](https://github.com/optuna/optuna):
+
+- `src/artifacts.jl`
+- `src/crossover.jl`
+- `src/journal.jl`
+- `src/optimize.jl`
+- `src/pruners.jl`
+- `src/samplers.jl`
+- `src/storage.jl`
+- `src/study.jl`
+- `src/trial.jl`
+- `src/types.jl`
+
+The API reference at `docs/src/api.md` renders these descriptions from the
+source docstrings.
+
+Optuna copyright:
+
+MIT License
+
+Copyright (c) 2018 Preferred Networks, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Lux.jl
+
+The polynomial-fitting documentation example in
+`docs/src/FittingPolynomial.md` is adapted from the Lux.jl example
+[“Fitting a Polynomial using
+MLP”](https://github.com/LuxDL/Lux.jl/blob/main/examples/PolynomialFitting/main.jl).
+
+Lux.jl copyright:
+
+MIT License
+
+Copyright (c) 2022 Avik Pal <avikpal@mit.edu> and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,6 +20,7 @@ makedocs(;
         "Getting Started" => ["First optimization" => "FirstHyperOpt.md"],
         "Examples" => ["Polynomial fitting" => "FittingPolynomial.md"],
         "API Reference" => "api.md",
+        "License" => "license.md",
     ],
 )
 

--- a/docs/src/FirstHyperOpt.md
+++ b/docs/src/FirstHyperOpt.md
@@ -103,3 +103,9 @@ The result should move toward `x = 2`, `y = -1`, and `use_offset = false`, becau
 Define the search space inside the objective with `suggest_int`, `suggest_float`, and `suggest_categorical`. This keeps the sampled values close to the code that uses them and also supports conditional spaces, where later suggestions depend on earlier choices.
 
 For larger objectives, move the actual workload into helper functions and keep the Optuna-specific suggestion calls near the top of the objective.
+
+## License
+
+Optuna.jl and this documentation page are licensed under the project MIT
+license. See the [License](license.md) page for the complete license text and
+the notices for third-party material used elsewhere in the documentation.

--- a/docs/src/FittingPolynomial.md
+++ b/docs/src/FittingPolynomial.md
@@ -149,3 +149,10 @@ best_data = JLD2.load(artifact_file)
 ```
 
 The artifact contains the trained parameters, model state, and hyperparameters that were saved in the objective.
+
+## License
+
+Optuna.jl and the original content on this page are licensed under the project
+MIT license. The polynomial-fitting material is adapted from Lux.jl under its
+MIT license. See the [License](license.md) page for both complete license texts
+and attribution.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -129,3 +129,10 @@ Optuna.jl uses CondaPkg for Python dependencies. These helpers are available whe
 is_conda_pkg_installed
 add_conda_pkg
 ```
+
+## License
+
+Optuna.jl and the original content on this page are licensed under the project
+MIT license. Portions of the rendered API documentation and interface
+descriptions are adapted from Optuna under its MIT license. See the
+[License](license.md) page for both complete license texts and attribution.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,70 @@
+# Optuna.jl
+
+Optuna.jl provides a Julia interface to the Python package [Optuna](https://optuna.org/), a framework for hyperparameter optimization. It lets Julia code define studies, ask Optuna for trial parameters, report intermediate values for pruning, and store the result history in an Optuna-compatible backend.
+
+Use Optuna.jl when you have an objective function that can be evaluated repeatedly with different parameters, for example model training, numerical solver configuration, preprocessing choices, or a simulation setup.
+
+## Installation
+
+Install Optuna.jl from the Julia package manager:
+
+```julia
+pkg> add Optuna
+```
+
+Optuna.jl uses [PythonCall.jl](https://github.com/JuliaPy/PythonCall.jl) and [CondaPkg.jl](https://github.com/JuliaPy/CondaPkg.jl) to load the Python Optuna package and optional Python dependencies. The package manages the Python side for the common workflows shown in these docs.
+
+## A minimal study
+
+The core workflow is:
+
+1. Create storage for the trial history.
+2. Create a `Study`.
+3. Define an objective function that accepts a `Trial`.
+4. Suggest parameters inside the objective.
+5. Run `optimize` and inspect the best result.
+
+```julia
+using Optuna
+
+storage = InMemoryStorage()
+artifact_store = FileSystemArtifactStore("artifacts")
+
+study = Study(
+    "minimal-study",
+    artifact_store,
+    storage;
+    sampler=TPESampler(seed=1),
+    direction="minimize",
+)
+
+function objective(trial::Trial)
+    x = suggest_float(trial, "x", -10.0, 10.0)
+    y = suggest_int(trial, "y", -5, 5)
+
+    return (x - 2.0)^2 + (y + 1)^2
+end
+
+optimize(study, objective; n_trials=25)
+
+best_params(study)
+best_value(study)
+```
+
+## Documentation map
+
+Start with [Overview](@ref) for the concepts behind studies, trials, samplers, pruners, storage, and artifacts.
+
+The [First optimization](@ref) page walks through a complete small workflow with pruning and artifacts.
+
+The [Polynomial fitting](@ref) example shows how to wrap a training loop in an Optuna objective.
+
+The [Reference](@ref) page explains the available Optuna.jl building blocks and links to their docstrings.
+
+## License
+
+Optuna.jl and this documentation page are licensed under the project MIT
+license. Portions of the API documentation and interface descriptions are
+adapted from Optuna, and the polynomial-fitting example is adapted from
+Lux.jl. See the [License](license.md) page for the complete project and
+third-party license texts.

--- a/docs/src/license.md
+++ b/docs/src/license.md
@@ -1,0 +1,94 @@
+# License
+
+## Optuna.jl
+
+Optuna.jl and its original documentation are distributed under the following
+MIT license:
+
+```text
+MIT License
+
+Copyright (c) 2026 Julian Trommer <julian.trommer@uni-a.de>, Valentin Höpfner <valentin.hoepfner@uni-a.de>, Andreas Hofmann <andreas.hofmann@uni-a.de>, Josef Kircher <josef.kircher@uni-a.de>, Tobias Thummerer <tobias.thummerer@uni-a.de>, and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## Third-party notices
+
+### Optuna
+
+Portions of Optuna.jl's API documentation and interface descriptions are
+adapted from [Optuna](https://github.com/optuna/optuna). The affected source
+files are identified in the repository's
+[`THIRD_PARTY_NOTICES.md`](https://github.com/una-auxme/Optuna.jl/blob/main/THIRD_PARTY_NOTICES.md).
+
+```text
+MIT License
+
+Copyright (c) 2018 Preferred Networks, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+### Lux.jl
+
+The [Polynomial fitting](@ref) documentation example is adapted from Lux.jl's
+[“Fitting a Polynomial using
+MLP”](https://github.com/LuxDL/Lux.jl/blob/main/examples/PolynomialFitting/main.jl)
+example.
+
+```text
+MIT License
+
+Copyright (c) 2022 Avik Pal <avikpal@mit.edu> and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -100,3 +100,9 @@ julia -t 4,1
 ```
 
 For distributed or repeated optimization runs, use persistent storage so that workers share the same trial history.
+
+## License
+
+Optuna.jl and this documentation page are licensed under the project MIT
+license. See the [License](license.md) page for the complete license text and
+the notices for third-party material used elsewhere in the documentation.

--- a/src/artifacts.jl
+++ b/src/artifacts.jl
@@ -2,6 +2,11 @@
 # Copyright (c) 2026 Julian Trommer, Valentin Höpfner, Andreas Hofmann, Josef Kircher, Tobias Thummerer, and contributors
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
+# Portions of this file's API documentation and interface descriptions are
+# adapted from Optuna.
+# Copyright (c) 2018 Preferred Networks, Inc.
+# Licensed under the MIT license. See THIRD_PARTY_NOTICES.md in the project root for details.
+#
 
 using JLD2
 

--- a/src/crossover.jl
+++ b/src/crossover.jl
@@ -2,6 +2,11 @@
 # Copyright (c) 2026 Julian Trommer, Valentin Höpfner, Andreas Hofmann, Josef Kircher, Tobias Thummerer, and contributors
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
+# Portions of this file's API documentation and interface descriptions are
+# adapted from Optuna.
+# Copyright (c) 2018 Preferred Networks, Inc.
+# Licensed under the MIT license. See THIRD_PARTY_NOTICES.md in the project root for details.
+#
 
 """
     UniformCrossover(

--- a/src/journal.jl
+++ b/src/journal.jl
@@ -2,6 +2,11 @@
 # Copyright (c) 2026 Julian Trommer, Valentin Höpfner, Andreas Hofmann, Josef Kircher, Tobias Thummerer, and contributors
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
+# Portions of this file's API documentation and interface descriptions are
+# adapted from Optuna.
+# Copyright (c) 2018 Preferred Networks, Inc.
+# Licensed under the MIT license. See THIRD_PARTY_NOTICES.md in the project root for details.
+#
 
 """
     JournalFileSymlinkLock(

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -2,6 +2,11 @@
 # Copyright (c) 2026 Julian Trommer, Valentin Höpfner, Andreas Hofmann, Josef Kircher, Tobias Thummerer, and contributors
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
+# Portions of this file's API documentation and interface descriptions are
+# adapted from Optuna.
+# Copyright (c) 2018 Preferred Networks, Inc.
+# Licensed under the MIT license. See THIRD_PARTY_NOTICES.md in the project root for details.
+#
 
 """
     optimize(

--- a/src/pruners.jl
+++ b/src/pruners.jl
@@ -2,6 +2,11 @@
 # Copyright (c) 2026 Julian Trommer, Valentin Höpfner, Andreas Hofmann, Josef Kircher, Tobias Thummerer, and contributors
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
+# Portions of this file's API documentation and interface descriptions are
+# adapted from Optuna.
+# Copyright (c) 2018 Preferred Networks, Inc.
+# Licensed under the MIT license. See THIRD_PARTY_NOTICES.md in the project root for details.
+#
 
 """
     MedianPruner(

--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -2,6 +2,11 @@
 # Copyright (c) 2026 Julian Trommer, Valentin Höpfner, Andreas Hofmann, Josef Kircher, Tobias Thummerer, and contributors
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
+# Portions of this file's API documentation and interface descriptions are
+# adapted from Optuna.
+# Copyright (c) 2018 Preferred Networks, Inc.
+# Licensed under the MIT license. See THIRD_PARTY_NOTICES.md in the project root for details.
+#
 
 """
     RandomSampler(seed=nothing::Union{Nothing,Integer}) <: BaseSampler

--- a/src/storage.jl
+++ b/src/storage.jl
@@ -2,6 +2,11 @@
 # Copyright (c) 2026 Julian Trommer, Valentin Höpfner, Andreas Hofmann, Josef Kircher, Tobias Thummerer, and contributors
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
+# Portions of this file's API documentation and interface descriptions are
+# adapted from Optuna.
+# Copyright (c) 2018 Preferred Networks, Inc.
+# Licensed under the MIT license. See THIRD_PARTY_NOTICES.md in the project root for details.
+#
 """
     RDBStorage(
         url::String

--- a/src/study.jl
+++ b/src/study.jl
@@ -2,6 +2,11 @@
 # Copyright (c) 2026 Julian Trommer, Valentin Höpfner, Andreas Hofmann, Josef Kircher, Tobias Thummerer, and contributors
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
+# Portions of this file's API documentation and interface descriptions are
+# adapted from Optuna.
+# Copyright (c) 2018 Preferred Networks, Inc.
+# Licensed under the MIT license. See THIRD_PARTY_NOTICES.md in the project root for details.
+#
 
 """
     Study(

--- a/src/trial.jl
+++ b/src/trial.jl
@@ -2,6 +2,11 @@
 # Copyright (c) 2026 Julian Trommer, Valentin Höpfner, Andreas Hofmann, Josef Kircher, Tobias Thummerer, and contributors
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
+# Portions of this file's API documentation and interface descriptions are
+# adapted from Optuna.
+# Copyright (c) 2018 Preferred Networks, Inc.
+# Licensed under the MIT license. See THIRD_PARTY_NOTICES.md in the project root for details.
+#
 
 """
     suggest_int(

--- a/src/types.jl
+++ b/src/types.jl
@@ -2,6 +2,11 @@
 # Copyright (c) 2026 Julian Trommer, Valentin Höpfner, Andreas Hofmann, Josef Kircher, Tobias Thummerer, and contributors
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
+# Portions of this file's API documentation and interface descriptions are
+# adapted from Optuna.
+# Copyright (c) 2018 Preferred Networks, Inc.
+# Licensed under the MIT license. See THIRD_PARTY_NOTICES.md in the project root for details.
+#
 
 # artifacts.jl
 abstract type BaseArtifactStore end


### PR DESCRIPTION
- document Optuna and Lux.jl-derived material
- add attribution headers to applicable source files
- add per-page license sections and a consolidated License page
- update Documenter navigation and preserve the dedicated docs homepage